### PR TITLE
Add docs management support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-07-16
+
+### Added
+- ClickUp Docs management (create, get, update, list, search)
+
 ## [0.1.0] - 2024-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Built by the [Diversio](https://diversio.com) team for streamlined AI-powered ta
 - **Comments & Collaboration** - Read and create comments on tasks
 - **User & Assignment Management** - List users, find by name/email, assign to tasks
 - **Status Management** - Update and track task statuses
+- **Docs Management** - Create and manage ClickUp Docs
 
 ### ✅ Productivity Features
 - **Bulk Operations** - Update or move multiple tasks at once
@@ -39,7 +40,6 @@ Built by the [Diversio](https://diversio.com) team for streamlined AI-powered ta
 ### ❌ What's NOT Included
 
 This server focuses on task management essentials. **Not supported:**
-- ClickUp Docs/Documents
 - Whiteboards
 - Dashboards
 - Automations/Workflows
@@ -210,7 +210,7 @@ VS Code now has built-in MCP support with GitHub Copilot and Agent Mode. Add to 
 2. In VS Code, ask GitHub Copilot: *"Can you list my ClickUp spaces using MCP tools?"*
 3. Check MCP server status with Command Palette → **"MCP: List Servers"**
 
-## Available Tools (28 Tools)
+## Available Tools (33 Tools)
 
 ### 📝 Task Management
 - `create_task` - Create new tasks
@@ -219,6 +219,13 @@ VS Code now has built-in MCP support with GitHub Copilot and Agent Mode. Add to 
 - `delete_task` - Delete tasks
 - `create_task_from_template` - Create from predefined templates
 - `create_task_chain` - Create dependent task sequences
+
+### 📄 Docs Management
+- `create_doc` - Create a new document
+- `get_doc` - Retrieve document details
+- `update_doc` - Update an existing document
+- `list_docs` - List documents in a folder or space
+- `search_docs` - Search documents across workspace
 
 ### 🔍 Task Discovery
 - `list_tasks` - List tasks with filtering options
@@ -295,7 +302,7 @@ Ask your AI assistant:
 ### Running Tests
 
 ```bash
-# Run all tests (62 tests)
+# Run all tests (72 tests)
 uv run pytest
 
 # Run with coverage

--- a/src/clickup_mcp/models.py
+++ b/src/clickup_mcp/models.py
@@ -267,3 +267,36 @@ class UpdateTaskRequest(BaseModel):
     start_date_time: Optional[bool] = None
     archived: Optional[bool] = None
     parent: Optional[str] = None
+
+
+class Document(BaseModel):
+    """ClickUp document model."""
+
+    id: str
+    name: str
+    content: Optional[str] = None
+    folder: Optional[Dict[str, Any]] = None
+    space: Optional[Dict[str, Any]] = None
+    url: Optional[str] = None
+
+
+class DocumentFolder(BaseModel):
+    """Folder for organizing documents."""
+
+    id: str
+    name: str
+    space: Optional[Dict[str, Any]] = None
+
+
+class CreateDocRequest(BaseModel):
+    """Request model for creating a document."""
+
+    name: str
+    content: str
+
+
+class UpdateDocRequest(BaseModel):
+    """Request model for updating a document."""
+
+    name: Optional[str] = None
+    content: Optional[str] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,3 +188,16 @@ def sample_comment():
         "resolved": False,
         "assignee": None,
     }
+
+
+@pytest.fixture
+def sample_document():
+    """Sample document data for testing."""
+    return {
+        "id": "doc123",
+        "name": "Sample Doc",
+        "content": "Hello world",
+        "folder": {"id": "folder123", "name": "Docs"},
+        "space": {"id": "space123", "name": "Test Space"},
+        "url": "https://app.clickup.com/docs/doc123",
+    }

--- a/tests/test_docs_client.py
+++ b/tests/test_docs_client.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from clickup_mcp.client import ClickUpClient
+
+
+class TestDocsClient:
+    """Tests for ClickUpClient docs methods."""
+
+    @pytest.mark.asyncio
+    async def test_create_doc(self, mock_client, mock_response, sample_document):
+        from clickup_mcp.models import CreateDocRequest, Document
+
+        mock_client.client.request = AsyncMock(return_value=mock_response(200, sample_document))
+
+        doc_req = CreateDocRequest(name="Doc", content="hello")
+        result = await mock_client.create_doc("folder123", doc_req)
+
+        assert isinstance(result, Document)
+        assert result.name == sample_document["name"]
+        mock_client.client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_doc(self, mock_client, mock_response, sample_document):
+        from clickup_mcp.models import Document
+
+        mock_client.client.request = AsyncMock(return_value=mock_response(200, sample_document))
+
+        result = await mock_client.get_doc("doc123")
+
+        assert isinstance(result, Document)
+        assert result.id == sample_document["id"]
+        mock_client.client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_doc(self, mock_client, mock_response, sample_document):
+        from clickup_mcp.models import Document, UpdateDocRequest
+
+        updated = {**sample_document, "name": "Updated"}
+        mock_client.client.request = AsyncMock(return_value=mock_response(200, updated))
+
+        req = UpdateDocRequest(name="Updated")
+        result = await mock_client.update_doc("doc123", req)
+
+        assert isinstance(result, Document)
+        assert result.name == "Updated"
+        mock_client.client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_docs(self, mock_client, mock_response, sample_document):
+        from clickup_mcp.models import Document
+
+        docs_data = {"docs": [sample_document]}
+        mock_client.client.request = AsyncMock(return_value=mock_response(200, docs_data))
+
+        result = await mock_client.list_docs(folder_id="folder123")
+
+        assert isinstance(result, list)
+        assert isinstance(result[0], Document)
+        mock_client.client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_docs(self, mock_client, mock_response, sample_document):
+        from clickup_mcp.models import Document
+
+        docs_data = {"docs": [sample_document]}
+        mock_client.client.request = AsyncMock(return_value=mock_response(200, docs_data))
+
+        result = await mock_client.search_docs(workspace_id="workspace123", query="design")
+
+        assert isinstance(result, list)
+        assert isinstance(result[0], Document)
+        mock_client.client.request.assert_called_once()

--- a/tests/test_docs_tools.py
+++ b/tests/test_docs_tools.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from clickup_mcp.tools import ClickUpTools
+
+
+class TestDocsTools:
+    """Tests for doc related tools."""
+
+    @pytest.fixture
+    async def tools(self, mock_client):
+        return ClickUpTools(mock_client)
+
+    @pytest.mark.asyncio
+    async def test_create_doc(self, tools, sample_document):
+        from clickup_mcp.models import Document
+
+        doc_obj = Document(**sample_document)
+        tools.client.create_doc = AsyncMock(return_value=doc_obj)
+
+        result = await tools.create_doc(folder_id="folder123", title="Doc", content="hi")
+
+        assert result["id"] == sample_document["id"]
+        assert result["name"] == sample_document["name"]
+        tools.client.create_doc.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_doc(self, tools, sample_document):
+        from clickup_mcp.models import Document
+
+        doc_obj = Document(**sample_document)
+        tools.client.get_doc = AsyncMock(return_value=doc_obj)
+
+        result = await tools.get_doc("doc123")
+
+        assert result["id"] == sample_document["id"]
+        assert result["name"] == sample_document["name"]
+        tools.client.get_doc.assert_called_once_with("doc123")
+
+    @pytest.mark.asyncio
+    async def test_update_doc(self, tools, sample_document):
+        from clickup_mcp.models import Document
+
+        updated = {**sample_document, "name": "Updated"}
+        doc_obj = Document(**updated)
+        tools.client.update_doc = AsyncMock(return_value=doc_obj)
+
+        result = await tools.update_doc("doc123", title="Updated")
+
+        assert result["id"] == sample_document["id"]
+        assert result["name"] == "Updated"
+        assert result["updated"] is True
+        tools.client.update_doc.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_docs(self, tools, sample_document):
+        from clickup_mcp.models import Document
+
+        doc_obj = Document(**sample_document)
+        tools.client.list_docs = AsyncMock(return_value=[doc_obj])
+
+        result = await tools.list_docs(folder_id="folder123")
+
+        assert result["count"] == 1
+        assert result["docs"][0]["id"] == sample_document["id"]
+        tools.client.list_docs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_docs(self, tools, sample_document):
+        from clickup_mcp.models import Document
+
+        doc_obj = Document(**sample_document)
+        tools.client.search_docs = AsyncMock(return_value=[doc_obj])
+
+        result = await tools.search_docs(query="design")
+
+        assert result["count"] == 1
+        assert result["docs"][0]["id"] == sample_document["id"]
+        tools.client.search_docs.assert_called_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,8 +26,8 @@ class TestClickUpMCPServer:
         """Test that all tool definitions are returned."""
         definitions = server.tools.get_tool_definitions()
 
-        # Should have all 27 tools
-        assert len(definitions) >= 24  # At least the documented tools
+        # Should have all 33 tools including docs management
+        assert len(definitions) >= 29  # At least the documented tools
 
         tool_names = [tool.name for tool in definitions]
 
@@ -44,6 +44,13 @@ class TestClickUpMCPServer:
         assert "log_time" in tool_names
         assert "create_task_from_template" in tool_names
         assert "get_team_workload" in tool_names
+
+        # Check for docs tools
+        assert "create_doc" in tool_names
+        assert "get_doc" in tool_names
+        assert "update_doc" in tool_names
+        assert "list_docs" in tool_names
+        assert "search_docs" in tool_names
 
     @pytest.mark.asyncio
     async def test_server_startup(self, server):


### PR DESCRIPTION
## Summary
- extend models with document dataclasses
- support docs CRUD endpoints in the client
- expose docs tools for create, read, update, list and search
- document the new capabilities and remove docs from the unsupported list
- record docs management in changelog
- add unit tests for docs client and tools and update server tests

## Testing
- `pre-commit run --files CHANGELOG.md README.md src/clickup_mcp/client.py src/clickup_mcp/models.py src/clickup_mcp/tools.py tests/conftest.py tests/test_server.py tests/test_docs_client.py tests/test_docs_tools.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687778622b448329b45e579e50f37c41